### PR TITLE
Added functionality to display domain age

### DIFF
--- a/src/lib/server/rdap/rdap.js
+++ b/src/lib/server/rdap/rdap.js
@@ -1,0 +1,16 @@
+import getRdapQureyServerByDomainName from "./usecases/getRdapQureyServerByDomainName";
+
+export default async function getRdapInfo(domainName) {
+    return getRdapInfoByDomainName(domainName);
+}
+
+async function getRdapInfoByDomainName(domainName) {
+    const rdapBootstrapDomainServer = "http://data.iana.org/rdap/dns.json";
+    const rdapServers = (await (await fetch(rdapBootstrapDomainServer)).json()).services;
+    const rdapQureyServer = getRdapQureyServerByDomainName(domainName, rdapServers);
+    if(rdapQureyServer == undefined) {
+        return `can't find rdap server for ${domainName}`; // TODO This is bad. do proper error message handling
+    }
+    const rdapQurey = (await (await fetch(`${rdapQureyServer}domain/${domainName}`)).json()); // TODO This is not valid rdap request. We need to follow links that have rel=related
+    return rdapQurey;
+}

--- a/src/lib/server/rdap/usecases/getRdapQureyServerByDomainName.js
+++ b/src/lib/server/rdap/usecases/getRdapQureyServerByDomainName.js
@@ -1,0 +1,34 @@
+export default function getRdapQureyServerByDomainName(domainName, serverList) {
+    const rdapQureyServer = matchRdapServerByDomain(domainName, serverList);
+    if(rdapQureyServer.length < 2) {
+        return undefined;
+    }
+    return rdapQureyServer[1];
+}
+
+function matchRdapServerByDomain(domainName, serverList) {
+    if(domainName === "") {
+        return [];
+    }
+
+    const serviceLink = serverList.find(service => {
+        return service[0].find(element => {
+            return element === domainName
+        }) != undefined;
+    });
+    if(serviceLink != undefined) {
+        return serviceLink;
+    }
+    const broaderDomainName = getBroaderDomainName(domainName);
+    return matchRdapServerByDomain(broaderDomainName, serverList);
+}
+
+
+// for a domain name like example.com return com
+function getBroaderDomainName(domainName) {
+    const [first, ...rest] = domainName.split('.');
+    if(rest.length < 1) {
+        return "";
+    }
+    return rest.join('.');
+}

--- a/src/routes/lookup/domain-age/+page.svelte
+++ b/src/routes/lookup/domain-age/+page.svelte
@@ -1,2 +1,25 @@
+<script>
+    import SiteUrlForm from "$lib/components/lookup/SiteUrlForm.svelte"
+    import {page} from "$app/stores"
+
+    const currentPath = $page.url.pathname;
+    const serverParameterName = "url";
+
+    let data = undefined;
+
+    async function checkSite(urlToCheck) {
+        const fetchUrl = currentPath + `?${serverParameterName}=${urlToCheck}`;
+        const response = await fetch(fetchUrl);
+        data = (await response.json()).data;
+    }
+</script>
+
 
 <h1><a href="/lookup/domain-age" style="text-decoration: none;">Domain Age</a></h1>
+
+<SiteUrlForm
+    label="Enter a site to see when it was first registered"
+    submit_button_text="whois"
+    on_submit={checkSite} />
+
+<p>{data}</p>

--- a/src/routes/lookup/domain-age/+server.js
+++ b/src/routes/lookup/domain-age/+server.js
@@ -1,0 +1,19 @@
+import getRdapInfo from "$lib/server/rdap/rdap";
+import { invalid } from '@sveltejs/kit';
+import getDomainAgeFromRdapInfo from "./usecases/getDomainAgeFromRdapInfo";
+
+export async function GET(request) {
+    const urlToCheck = request.url.searchParams.get('url');
+    const rdapInfo = await getRdapInfo(urlToCheck)
+                        .catch((error) => {
+                            console.log(error);
+                            return invalid(400, error.message);
+                        });
+    const data = getDomainAgeFromRdapInfo(rdapInfo);
+    return new Response(
+        JSON.stringify({
+            url_to_check: urlToCheck,
+            data,
+        })
+        );
+}

--- a/src/routes/lookup/domain-age/usecases/getDomainAgeFromRdapInfo.js
+++ b/src/routes/lookup/domain-age/usecases/getDomainAgeFromRdapInfo.js
@@ -1,0 +1,5 @@
+export default function getDomainAgeFromRdapInfo(rdapInfo) {
+    const events = rdapInfo.events;
+    const registrationDate = events[0].eventDate;
+    return registrationDate;
+}


### PR DESCRIPTION
This uses a very basic RDAP protocol client implementation. In the future, we need to follow rel = related links in order to obtain full RDAP info, but for simple domain age, it is not required to do so.